### PR TITLE
Clean-up the errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hedwig"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Aniruddha Maru <aniruddhamaru@gmail.com>",
     "Simonas Kazlauskas <hedwig@kazlauskas.me>"
@@ -29,7 +29,7 @@ required-features = ["google"]
 
 [dependencies]
 base64 = { version = "^0.10", optional = true }
-failure = "^0.1"
+thiserror = "1"
 google-pubsub1 = { version = "^1.0.8", optional = true }
 # This project intentionally uses an old version of Hyper. See
 # https://github.com/Byron/google-apis-rs/issues/173 for more

--- a/examples/publish.rs
+++ b/examples/publish.rs
@@ -1,6 +1,5 @@
 use std::env;
 
-use failure;
 use hedwig::{GooglePublisher, Hedwig, MajorVersion, Message, MinorVersion, Version};
 use serde::Serialize;
 use strum_macros::IntoStaticStr;
@@ -27,7 +26,7 @@ fn router(t: MessageType, v: MajorVersion) -> Option<&'static str> {
     }
 }
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     let google_credentials = env::var("GOOGLE_APPLICATION_CREDENTIALS")
         .expect("env var GOOGLE_APPLICATION_CREDENTIALS is required");
     let google_project =


### PR DESCRIPTION
This pull request cleans up the errors in this crate so that the following hold:

1. The errors implement `std::error::Error + Send + Sync + 'static` (verified by a test);
     * We no longer use `failure` as that failed to implement the standard error trait and ecosystem is moving away from it in general;
2. Renamed the primary error enumeration to `Error`: `hedwig::HedwigError` is just making us repeat ourselves, and the new way is more conventional;
3. Renamed the variants to not duplicate `Error`, `Failed`, `Cannot`, `Unable` or similar words that are already implied by the fact that these variants are inside an enum called `Error`.
4. Marked the error enums as `#[non_exhaustive]` for future proofing.
    * This in particular bumps the required Rust version to a quite recent one, IIRC this feature was stabilized one or two releases ago.

This work slightly regressed the `PublishError::MessagePublish` error variant by not preserving causation relationship with a formatted version of `google_pubsub1::Error`. The correct approach is to [fix this upstream](https://github.com/Byron/google-apis-rs/issues/228) and I don’t think it is worth it bending over ourselves and cluttering code in this library for minor gains in semantic information preservation.