### PR TITLE
We are asynchronous now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
       env: flags=
     - rust: stable
       env: flags=--features=google
-    - rust: stable
-      env: flags=--features=mock
 before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,26 +27,26 @@ name = "publish"
 required-features = ["google"]
 
 [dependencies]
-thiserror = "1"
-serde = { version = "^1.0", features = ["derive"] }
+futures = "0.3"
 serde_json = "^1"
+serde = { version = "^1.0", features = ["derive"] }
+thiserror = "1"
+url = "2"
 uuid = { version = "^0.7", features = ["serde", "v4"] }
 valico = { version = "^3.2" }
-url = "2"
-futures = "0.3"
 
 base64 = { version = "^0.10", optional = true }
+http = { version = "^0.2", optional = true }
+hyper = { version = "^0.13.1", optional = true }
 yup-oauth2 = { version = "4", optional = true }
-hyper = { version = "0.13.2", optional = true }
-http = { version = "0.2", optional = true }
 
 [dev-dependencies]
 assert_matches = "^1.3"
+hyper-openssl = "0.8.0"
 rust-embed="^4.3"
 strum = "^0.15"
 strum_macros = "^0.15"
-hyper-openssl = "0.8.0"
-tokio = "0.2"
+tokio = { version = "^0.2.4", features = ["macros"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,34 +20,33 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = []
-google = ["base64", "google-pubsub1", "yup-oauth2"]
-mock = []
+google = ["base64", "yup-oauth2", "hyper", "http"]
 
 [[example]]
 name = "publish"
 required-features = ["google"]
 
 [dependencies]
-base64 = { version = "^0.10", optional = true }
 thiserror = "1"
-google-pubsub1 = { version = "^1.0.8", optional = true }
-# This project intentionally uses an old version of Hyper. See
-# https://github.com/Byron/google-apis-rs/issues/173 for more
-# information.
-hyper = "^0.10"
-hyper-rustls = "^0.6"
 serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
-url = "^1.7"
+serde_json = "^1"
 uuid = { version = "^0.7", features = ["serde", "v4"] }
-valico = { version = "^3.1" }
-yup-oauth2 = { version = "^1.0", optional = true }
+valico = { version = "^3.2" }
+url = "2"
+futures = "0.3"
+
+base64 = { version = "^0.10", optional = true }
+yup-oauth2 = { version = "4", optional = true }
+hyper = { version = "0.13.2", optional = true }
+http = { version = "0.2", optional = true }
 
 [dev-dependencies]
 assert_matches = "^1.3"
 rust-embed="^4.3"
 strum = "^0.15"
 strum_macros = "^0.15"
+hyper-openssl = "0.8.0"
+tokio = "0.2"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/publish.rs
+++ b/examples/publish.rs
@@ -1,6 +1,8 @@
 use std::env;
 
-use hedwig::{GooglePublisher, Hedwig, MajorVersion, Message, MinorVersion, Version};
+use hedwig::{
+    publishers::GooglePubSubPublisher, Hedwig, MajorVersion, Message, MinorVersion, Version,
+};
 use serde::Serialize;
 use strum_macros::IntoStaticStr;
 
@@ -19,21 +21,7 @@ const VERSION_1_0: Version = Version(MajorVersion(1), MinorVersion(0));
 
 const PUBLISHER: &str = "myapp";
 
-fn router(t: MessageType, v: MajorVersion) -> Option<&'static str> {
-    match (t, v) {
-        (MessageType::UserCreated, MajorVersion(1)) => Some("dev-user-created-v1"),
-        _ => None,
-    }
-}
-
-fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
-    let google_credentials = env::var("GOOGLE_APPLICATION_CREDENTIALS")
-        .expect("env var GOOGLE_APPLICATION_CREDENTIALS is required");
-    let google_project =
-        env::var("GOOGLE_CLOUD_PROJECT").expect("env var GOOGLE_CLOUD_PROJECT is required");
-
-    let schema = r#"
-{
+const SCHEMA: &str = r#"{
   "$id": "https://hedwig.standard.ai/schema",
   "$schema": "https://json-schema.org/draft-04/schema#",
   "description": "Example Schema",
@@ -65,24 +53,66 @@ fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
   }
 }"#;
 
-    let publisher = GooglePublisher::new(google_credentials, google_project)?;
+fn router(t: MessageType, v: MajorVersion) -> Option<&'static str> {
+    match (t, v) {
+        (MessageType::UserCreated, MajorVersion(1)) => Some("dev-user-created-v1"),
+        _ => None,
+    }
+}
 
-    let hedwig = Hedwig::new(schema, PUBLISHER, publisher, router)?;
+async fn run() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let google_project =
+        env::var("GOOGLE_CLOUD_PROJECT").expect("env var GOOGLE_CLOUD_PROJECT is required");
+    let google_credentials = env::var("GOOGLE_APPLICATION_CREDENTIALS")
+        .expect("env var GOOGLE_APPLICATION_CREDENTIALS is required");
+    let secret = yup_oauth2::read_service_account_key(google_credentials)
+        .await
+        .expect("$GOOGLE_APPLICATION_CREDENTIALS is not a valid service account key");
+
+    let client = hyper::Client::builder().build(hyper_openssl::HttpsConnector::new()?);
+    let authenticator = yup_oauth2::ServiceAccountAuthenticator::builder(secret)
+        .hyper_client(client.clone())
+        .build()
+        .await
+        .expect("could not create an authenticator");
+
+    let publisher = GooglePubSubPublisher::new(google_project, client, authenticator);
+
+    let hedwig = Hedwig::new(SCHEMA, PUBLISHER, publisher, router)?;
 
     let data = UserCreatedData {
         user_id: "U_123".into(),
     };
 
     let message_id = uuid::Uuid::new_v4();
-    let mut builder = hedwig.build_publish();
+    let mut builder = hedwig.build_batch();
     builder.message(
         Message::new(MessageType::UserCreated, VERSION_1_0, data)
             .id(message_id)
             .header("request_id", uuid::Uuid::new_v4().to_string()),
     )?;
-    builder.publish()?;
 
-    println!("Published message {}", message_id);
+    println!("Published messages {:?}", builder.publish().await?);
 
     Ok(())
+}
+
+fn main() {
+    let mut rt = tokio::runtime::Builder::new()
+        .basic_scheduler()
+        .enable_all()
+        .build()
+        .expect("runtime builds");
+    match rt.block_on(run()) {
+        Ok(_) => std::process::exit(0),
+        Err(e) => {
+            eprintln!("error: {}", e);
+            let mut source = e.source();
+            while let Some(src) = source {
+                eprintln!("  caused by: {}", src);
+                source = src.source();
+            }
+            std::process::exit(1);
+        }
+    }
 }

--- a/src/google_publisher.rs
+++ b/src/google_publisher.rs
@@ -180,7 +180,7 @@ fn serialize_validated_messages<S: serde::Serializer>(
             // Would be better with `S::to_string(&element)` if it was a thing. Then we could
             // properly propagate the error here... That said serde_json probably cannot fail.
             // Hopefully.
-            &serde_json::to_vec(&element).expect("could not serialize message contents")
+            &serde_json::to_vec(&element).expect("could not serialize message contents"),
         );
         serde::ser::SerializeSeq::serialize_element(
             &mut seq,

--- a/src/google_publisher.rs
+++ b/src/google_publisher.rs
@@ -1,0 +1,208 @@
+use base64;
+use futures::{TryFutureExt, TryStreamExt};
+use std::{borrow::Cow, future::Future, pin::Pin, sync::Arc, task};
+use yup_oauth2::authenticator::Authenticator;
+
+use crate::{PublisherResult, ValidatedMessage};
+
+#[derive(Debug, thiserror::Error)]
+enum GooglePubsubError {
+    #[error("Could not get authentication token")]
+    GetAuthToken(#[source] yup_oauth2::Error),
+    #[error("Could not POST the request with messages")]
+    PostMessages(#[source] hyper::Error),
+    #[error("Could not construct the request URI")]
+    ConstructRequestUri(#[source] http::uri::InvalidUri),
+    #[error("Could not construct the request")]
+    ConstructRequest(#[source] http::Error),
+    #[error("Could not serialize a publish request")]
+    SerializePublishRequest(#[source] serde_json::Error),
+    #[error("Publish request failed with status code {1}")]
+    ResponseStatus(
+        #[source] Option<Box<dyn std::error::Error + Sync + Send>>,
+        http::StatusCode,
+    ),
+    #[error("Could not parse the response body")]
+    ResponseParse(#[source] serde_json::Error),
+    #[error("Could not receive the response body")]
+    ResponseBodyReceive(#[source] hyper::Error),
+}
+
+/// A publisher that uses the Google Cloud Pub/Sub service as a message transport
+///
+/// # Examples
+///
+/// ```no_run
+/// async {
+///     let google_project =
+///         std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
+///     let google_credentials = std::env::var("GOOGLE_APPLICATION_CREDENTIALS").unwrap();
+///     let secret = yup_oauth2::read_service_account_key(google_credentials)
+///         .await
+///         .expect("$GOOGLE_APPLICATION_CREDENTIALS is not a valid service account key");
+///     let client = hyper::Client::builder().build(hyper_openssl::HttpsConnector::new()?);
+///     let authenticator = yup_oauth2::ServiceAccountAuthenticator::builder(secret)
+///         .hyper_client(client.clone())
+///         .build()
+///         .await
+///         .expect("could not create an authenticator");
+///     Ok::<_, Box<dyn std::error::Error>>(
+///         hedwig::publishers::GooglePubSubPublisher::new(google_project, client, authenticator)
+///     )
+/// };
+/// ```
+#[allow(missing_debug_implementations)]
+pub struct GooglePubSubPublisher<C>(Arc<PublisherInner<C>>);
+
+struct PublisherInner<C> {
+    google_cloud_project: Cow<'static, str>,
+    client: hyper::Client<C>,
+    authenticator: Authenticator<C>,
+}
+
+impl<C> GooglePubSubPublisher<C> {
+    /// Create a new Google Cloud Pub/Sub publisher
+    pub fn new<P>(
+        project: P,
+        client: hyper::Client<C>,
+        authenticator: Authenticator<C>,
+    ) -> GooglePubSubPublisher<C>
+    where
+        P: Into<Cow<'static, str>>,
+    {
+        GooglePubSubPublisher(Arc::new(PublisherInner {
+            google_cloud_project: project.into(),
+            client,
+            authenticator,
+        }))
+    }
+}
+
+impl<C> crate::Publisher for GooglePubSubPublisher<C>
+where
+    C: hyper::client::connect::Connect + Clone + Send + Sync + 'static,
+{
+    type MessageId = String;
+    type PublishFuture = GooglePubSubPublishFuture;
+
+    fn publish(&self, topic: &'static str, messages: Vec<ValidatedMessage>) -> Self::PublishFuture {
+        let arc = self.0.clone();
+        GooglePubSubPublishFuture(Box::pin(async move {
+            let result = async {
+                const AUTH_SCOPES: [&str; 1] = ["https://www.googleapis.com/auth/pubsub"];
+                let token = arc
+                    .authenticator
+                    .token(&AUTH_SCOPES)
+                    .await
+                    .map_err(GooglePubsubError::GetAuthToken)?;
+                let uri = http::Uri::from_maybe_shared(format!(
+                    "https://pubsub.googleapis.com/v1/projects/{0}/topics/{1}:publish",
+                    arc.google_cloud_project, topic
+                ))
+                .map_err(GooglePubsubError::ConstructRequestUri)?;
+                let data = serde_json::to_vec(&PubsubPublishRequestSchema {
+                    messages: &messages,
+                })
+                .map_err(GooglePubsubError::SerializePublishRequest)?;
+                let request = http::Request::post(uri)
+                    .header(
+                        http::header::AUTHORIZATION,
+                        format!("Bearer {}", token.as_str()),
+                    )
+                    .header(http::header::ACCEPT, "application/json")
+                    .body(hyper::Body::from(data))
+                    .map_err(GooglePubsubError::ConstructRequest)?;
+                let response = arc
+                    .client
+                    .request(request)
+                    .map_err(GooglePubsubError::PostMessages)
+                    .await?;
+                let (parts, body) = response.into_parts();
+                let body_data = body
+                    .map_ok(|v| v.to_vec())
+                    .try_concat()
+                    .map_err(GooglePubsubError::ResponseBodyReceive)
+                    .await?;
+                if !parts.status.is_success() {
+                    let src = serde_json::from_slice(&body_data)
+                        .ok()
+                        .map(|v: PubsubPublishFailResponseSchema| v.error.message.into());
+                    return Err(GooglePubsubError::ResponseStatus(src, parts.status));
+                }
+                let rsp: PubsubPublishResponseSchema =
+                    serde_json::from_slice(&body_data).map_err(GooglePubsubError::ResponseParse)?;
+                Ok(rsp)
+            }
+            .await;
+            match result {
+                Ok(PubsubPublishResponseSchema { message_ids }) => {
+                    PublisherResult::Success(message_ids)
+                }
+                Err(e) => PublisherResult::OneError(e.into(), messages),
+            }
+        }))
+    }
+}
+
+/// The `GooglePubSubPublisher::publish` future
+pub struct GooglePubSubPublishFuture(
+    Pin<Box<dyn Future<Output = PublisherResult<String>> + Send + 'static>>,
+);
+
+impl Future for GooglePubSubPublishFuture {
+    type Output = PublisherResult<String>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+        Pin::new(&mut self.0).poll(cx)
+    }
+}
+
+/// Schema for the Google PubsubMessage REST API type
+#[derive(serde::Serialize)]
+struct PubsubMessageSchema<'a> {
+    data: &'a str,
+    attributes: &'a crate::Headers,
+}
+
+/// Schema for the Google PubsubRequest REST API type
+#[derive(serde::Serialize)]
+struct PubsubPublishRequestSchema<'a> {
+    #[serde(serialize_with = "serialize_validated_messages")]
+    messages: &'a [ValidatedMessage],
+}
+
+fn serialize_validated_messages<S: serde::Serializer>(
+    msgs: &[ValidatedMessage],
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let mut seq = serializer.serialize_seq(Some(msgs.len()))?;
+    for element in msgs {
+        // Would also be happy with `S::to_string(&element)` if it was a thing...?
+        let raw_message = base64::encode(&serde_json::to_string(&element).expect("welp"));
+        serde::ser::SerializeSeq::serialize_element(
+            &mut seq,
+            &PubsubMessageSchema {
+                data: &raw_message,
+                attributes: &element.metadata.headers,
+            },
+        )?;
+    }
+    serde::ser::SerializeSeq::end(seq)
+}
+
+/// Schema for the Google PubsubResponse REST API type
+#[derive(serde::Deserialize)]
+struct PubsubPublishResponseSchema {
+    #[serde(rename = "messageIds")]
+    message_ids: Vec<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct PubsubPublishFailResponseSchema {
+    error: PubsubPublishErrorSchema,
+}
+
+#[derive(serde::Deserialize)]
+struct PubsubPublishErrorSchema {
+    message: String,
+}

--- a/src/google_publisher.rs
+++ b/src/google_publisher.rs
@@ -27,6 +27,8 @@ enum GooglePubsubError {
     ResponseBodyReceive(#[source] hyper::Error),
 }
 
+const JSON_METATYPE: &str = "application/json";
+
 /// A publisher that uses the Google Cloud Pub/Sub service as a message transport
 ///
 /// # Examples
@@ -108,7 +110,8 @@ where
                         http::header::AUTHORIZATION,
                         format!("Bearer {}", token.as_str()),
                     )
-                    .header(http::header::ACCEPT, "application/json")
+                    .header(http::header::ACCEPT, JSON_METATYPE)
+                    .header(http::header::CONTENT_TYPE, JSON_METATYPE)
                     .body(hyper::Body::from(data))
                     .map_err(GooglePubsubError::ConstructRequest)?;
                 let response = arc

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+#![deny(
+    missing_docs,
+    unused_import_braces,
+    unused_qualifications,
+    intra_doc_link_resolution_failure,
+    clippy::all
+)]
 //! A Hedwig library for Rust. Hedwig is a message bus that works with arbitrary pubsub services
 //! such as AWS SNS/SQS or Google Cloud Pubsub. Messages are validated using a JSON schema. The
 //! publisher and consumer are de-coupled and fan-out is supported out of the box.
@@ -184,9 +191,9 @@ pub trait Publisher {
     ///
     /// # Return value
     ///
-    /// Shall return [`PublisherResult::Success`](PublisherResult::Success) only if all of the messages are successfully
-    /// published. Otherwise `PublisherResult::OneError` or `PublisherResult::PerMessage` shall be
-    /// returned to indicate an error.
+    /// Shall return [`PublisherResult::Success`](PublisherResult::Success) only if all of the
+    /// messages are successfully published. Otherwise `PublisherResult::OneError` or
+    /// `PublisherResult::PerMessage` shall be returned to indicate an error.
     fn publish(&self, topic: &'static str, messages: Vec<ValidatedMessage>) -> Self::PublishFuture;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,6 @@ use std::{
 };
 
 use futures::stream::StreamExt;
-use serde_json;
 use uuid::Uuid;
 use valico::json_schema::{SchemaError, Scope, ValidationState};
 
@@ -157,6 +156,8 @@ pub enum Error {
     ),
 }
 
+type AnyError = Box<dyn std::error::Error + Send + Sync>;
+
 /// The special result type for [`Publisher::publish`](trait.Publisher.html)
 #[derive(Debug)]
 pub enum PublisherResult<Id> {
@@ -165,14 +166,11 @@ pub enum PublisherResult<Id> {
     /// Contains a vector of published message IDs.
     Success(Vec<Id>),
     /// Publisher failed to publish any of the messages.
-    OneError(
-        Box<dyn std::error::Error + Send + Sync>,
-        Vec<ValidatedMessage>,
-    ),
+    OneError(AnyError, Vec<ValidatedMessage>),
     /// Publisher failed to publish some of the messages.
     ///
     /// The error type has a per-message granularity.
-    PerMessage(Vec<Result<Id, (Box<dyn std::error::Error + Send + Sync>, ValidatedMessage)>>),
+    PerMessage(Vec<Result<Id, (AnyError, ValidatedMessage)>>),
 }
 
 /// Interface for message publishers

--- a/src/mock_publisher.rs
+++ b/src/mock_publisher.rs
@@ -48,7 +48,7 @@ impl Publisher for MockPublisher {
     type PublishFuture = MockPublishFuture;
 
     fn publish(&self, topic: &'static str, messages: Vec<ValidatedMessage>) -> Self::PublishFuture {
-        let mut lock = self.0.lock().expect("lock");
+        let mut lock = self.0.lock().expect("this mutex cannot get poisoned");
         let num_messages = messages.len();
         let mut ids = Vec::with_capacity(num_messages);
         for message in messages {

--- a/src/mock_publisher.rs
+++ b/src/mock_publisher.rs
@@ -1,0 +1,73 @@
+use crate::{Publisher, PublisherResult, ValidatedMessage};
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task,
+};
+use uuid::Uuid;
+
+/// A mock publisher that stores messages in-memory for later verification
+///
+/// This is useful primarily in tests.
+///
+/// # Examples
+///
+/// ```
+/// use hedwig::publishers::MockPublisher;
+/// let publisher = MockPublisher::default();
+/// let publisher_view = publisher.clone();
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct MockPublisher(Arc<Mutex<Vec<(&'static str, ValidatedMessage)>>>);
+
+impl MockPublisher {
+    /// Verify that a message was published. This method asserts that the message you expected to
+    /// be published, was indeed published
+    ///
+    /// Panics if the message was not published.
+    pub fn assert_message_published(&self, topic: &'static str, uuid: Uuid) {
+        {
+            let lock = self.0.lock().expect("this mutex cannot get poisoned");
+            for (mt, msg) in &lock[..] {
+                if mt == &topic && msg.id == uuid {
+                    return;
+                }
+            }
+        }
+        panic!(
+            "Message with uuid {} was not published to topic {}",
+            uuid, topic
+        );
+    }
+}
+
+impl Publisher for MockPublisher {
+    type MessageId = Uuid;
+    type PublishFuture = MockPublishFuture;
+
+    fn publish(&self, topic: &'static str, messages: Vec<ValidatedMessage>) -> Self::PublishFuture {
+        let mut lock = self.0.lock().expect("lock");
+        let num_messages = messages.len();
+        let mut ids = Vec::with_capacity(num_messages);
+        for message in messages {
+            ids.push(message.id);
+            lock.push((topic, message));
+        }
+        MockPublishFuture(ids)
+    }
+}
+
+pub struct MockPublishFuture(Vec<Uuid>);
+
+impl Future for MockPublishFuture {
+    type Output = PublisherResult<Uuid>;
+
+    fn poll(mut self: Pin<&mut Self>, _: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+        task::Poll::Ready(PublisherResult::Success(std::mem::replace(
+            &mut self.0,
+            Vec::new(),
+        )))
+    }
+}

--- a/src/null_publisher.rs
+++ b/src/null_publisher.rs
@@ -1,0 +1,36 @@
+use std::{future::Future, pin::Pin, task};
+
+use crate::{Publisher, PublisherResult, ValidatedMessage};
+
+/// A blackhole publisher that doesn't publish messages
+///
+/// Great for conditionally enabling publishing.
+///
+/// # Examples
+///
+/// ```
+/// use hedwig::publishers::NullPublisher;
+/// let publisher = NullPublisher::default();
+/// ```
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NullPublisher;
+
+impl Publisher for NullPublisher {
+    type MessageId = ();
+    type PublishFuture = NullPublishFuture;
+
+    fn publish(&self, _: &'static str, messages: Vec<ValidatedMessage>) -> Self::PublishFuture {
+        NullPublishFuture(messages.len())
+    }
+}
+
+/// Future for `NullPublisher::publish`.
+pub struct NullPublishFuture(usize);
+
+impl Future for NullPublishFuture {
+    type Output = PublisherResult<()>;
+
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+        task::Poll::Ready(PublisherResult::Success(vec![(); self.0]))
+    }
+}


### PR DESCRIPTION
This is a fairly large PR that includes many improvements, among them:

1. Make publishing async. This necessitated dropping use of the generated google API libraries, which I think is perfectly fine given the super tiny amount of API surface that we interface with;
2. Make library more resilient to failure. A most notable instance of this is the `PublishBatch` not discarding messages that failed to publish for whatever reason. Instead those messages are retained and can be retried with a repeated call to `publish`;
3. I also made the library assume less about how people might want to use this. A good example of this is `GooglePubSubPublisher` accepting an arbitrary `oauth2` authenticator (so that different strategies could be chosen by the user; previously we supported service accounts only).