### PR TITLE
Take the Authenticator as an Arc

### DIFF
--- a/examples/publish.rs
+++ b/examples/publish.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::sync::Arc;
 
 use hedwig::{
     publishers::GooglePubSubPublisher, Hedwig, MajorVersion, Message, MinorVersion, Version,
@@ -70,11 +71,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error + 'static>> {
         .expect("$GOOGLE_APPLICATION_CREDENTIALS is not a valid service account key");
 
     let client = hyper::Client::builder().build(hyper_tls::HttpsConnector::new());
-    let authenticator = yup_oauth2::ServiceAccountAuthenticator::builder(secret)
+    let authenticator = Arc::new(yup_oauth2::ServiceAccountAuthenticator::builder(secret)
         .hyper_client(client.clone())
         .build()
         .await
-        .expect("could not create an authenticator");
+        .expect("could not create an authenticator"));
 
     let publisher = GooglePubSubPublisher::new(google_project, client, authenticator);
 


### PR DESCRIPTION
Previous API would consume instances of the Authenticator and therefore
prevent users from enabling token reuse between publishers or other
oauth-enabled applications.

This is likely something that can be removed again once/if
dermesser/yup-oauth2#133 is resolved.

Based on #13 for new CI, review last commit only.