### PR TITLE
Refine the list of transient errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hedwig"
-version = "2.0.0"
+version = "2.1.0"
 authors = [
     "Aniruddha Maru <aniruddhamaru@gmail.com>",
     "Simonas Kazlauskas <hedwig@kazlauskas.me>"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,11 +286,14 @@ impl PublishBatch {
         P: Publisher,
         P::PublishStream: Unpin,
     {
-        self.messages.into_iter().map(|(topic, msgs)| {
-            publisher
-                .publish(topic, msgs.iter())
-                .zip(stream::iter(msgs.into_iter()))
-                .map(move |(r, m)| (r, topic, m))
-        }).collect::<stream::SelectAll<_>>()
+        self.messages
+            .into_iter()
+            .map(|(topic, msgs)| {
+                publisher
+                    .publish(topic, msgs.iter())
+                    .zip(stream::iter(msgs.into_iter()))
+                    .map(move |(r, m)| (r, topic, m))
+            })
+            .collect::<stream::SelectAll<_>>()
     }
 }

--- a/src/validators/json_schema.rs
+++ b/src/validators/json_schema.rs
@@ -88,7 +88,7 @@ impl JsonSchemaValidator {
         let msg_schema = self
             .scope
             .resolve(&msg_schema_url)
-            .ok_or_else(|| JsonSchemaValidatorError::SchemaUrlResolve(msg_schema_url))?;
+            .ok_or(JsonSchemaValidatorError::SchemaUrlResolve(msg_schema_url))?;
         let value = serde_json::to_value(data).map_err(JsonSchemaValidatorError::SerializeData)?;
         let validation_state = msg_schema.validate(&value);
         if !validation_state.is_strictly_valid() {


### PR DESCRIPTION
Typically we won't want to retry sending message if we get an
authentication failure (403), a missing topic (404) etc. But we still
may want to retry if Google is having server troubles (5xx).