### PR TITLE
Add traits for Consumers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ prost = { version = "0.7", optional = true, features = ["std"], default-features
 
 [dev-dependencies]
 hyper-tls = "0.5.0"
+prost = { version = "0.7", features = ["std", "prost-derive"] }
 tokio = { version = "1", features = ["macros", "rt"] }
 serde = { version = "1", features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ categories = ["asynchronous", "web-programming"]
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["sink"]
+default = ["consume", "sink"]
 
-# Whether publishing is enabled
+# Whether publishing/consuming is enabled
 publish = []
+consume = ["async-trait", "either"]
 
 # Publishers
 google = ["base64", "yup-oauth2", "hyper", "http", "serde_json", "serde", "serde/derive", "uuid/serde"]
@@ -37,13 +38,15 @@ name = "publish"
 required-features = ["google", "json-schema"]
 
 [dependencies]
+bytes = "1"
 futures-util = { version = "0.3", features = ["std"], default-features = false }
 pin-project = "1"
 thiserror = { version = "1", default-features = false }
 url = { version = "2", default-features = false }
 uuid = { version = "^0.8", features = ["v4"], default-features = false }
 
-either = { version = "1", optional = true, default-features = false }
+async-trait = { version = "0.1", optional = true }
+either = { version = "1", optional = true, features = ["use_std"], default-features = false }
 serde = { version = "^1.0", optional = true, default-features = false }
 serde_json = { version = "^1", features = ["std"], optional = true, default-features = false }
 valico = { version = "^3.2", optional = true, default-features = false }

--- a/src/consume/mod.rs
+++ b/src/consume/mod.rs
@@ -1,0 +1,201 @@
+//! Types, traits, and functions necessary to consume messages using hedwig
+//!
+//! See the [`Consumer`] trait and [`consume`] function as entry points.
+
+use crate::ValidatedMessage;
+use async_trait::async_trait;
+use either::Either;
+use futures_util::stream;
+use pin_project::pin_project;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// Message consumers ingest messages from a queue service and present them to the user application
+/// as a [`Stream`](futures_util::stream::Stream).
+///
+/// ## Acknowledging Messages
+/// Typically message services deliver messages with a particular delivery time window, during
+/// which this message won't be sent to other consumers. In AWS SQS this is called the [visibility
+/// timeout][AWS], and in GCP PubSub this is the [ack deadline][GCP].
+///
+/// If a message is successfully acknowledged within this time, it will be considered processed and
+/// not delivered to other consumers (and possibly deleted depending on the service's
+/// configuration). A message can conversely be negatively-acknowledged, to indicate e.g.
+/// processing has failed and the message should be delivered again to some consumer. This time
+/// window can also be modified for each message, to allow for longer or shorter message processing
+/// than the default configured time window.
+///
+/// Implementations of this trait do not ack/nack/modify messages themselves, and instead present
+/// this functionality to users with the [`AcknowledgeableMessage`] type. Message processors are
+/// responsible for handling message acknowledgement, including extensions for processing time as
+/// necessary.
+// If we had async drop, sending nacks on drop would be nice. Alas, rust isn't there yet
+///
+/// Bear in mind that message delivery and acknowledgement are all best-effort in distributed
+/// message services. An acknowledged or extended message may still be re-delivered for any number
+/// of reasons, and applications should be made resilient to such events.
+///
+/// [AWS]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
+/// [GCP]: https://cloud.google.com/pubsub/docs/subscriber
+pub trait Consumer {
+    /// The type of acknowledgement tokens produced by the underlying service implementation
+    type AckToken: AcknowledgeToken;
+    /// Errors encountered while streaming messages
+    type Error: std::error::Error + Send + Sync + 'static;
+    /// The stream returned by [`stream`]
+    type Stream: stream::Stream<
+        Item = Result<AcknowledgeableMessage<Self::AckToken, ValidatedMessage>, Self::Error>,
+    >;
+
+    /// Begin pulling messages from the backing message service
+    fn stream(self) -> Self::Stream;
+}
+
+/// Create a stream of decoded messages using the given [`Consumer`] and a validator for the given
+/// [decodable](DecodableMessage) message
+pub fn consume<C, M>(
+    consumer: C,
+    validator: M::Validator,
+) -> MessageStream<C::Stream, M::Validator, M>
+where
+    C: Consumer,
+    M: DecodableMessage,
+{
+    MessageStream {
+        stream: consumer.stream(),
+        validator,
+        _message_type: std::marker::PhantomData,
+    }
+}
+
+/// Messages which can be decoded from a [`ValidatedMessage`] stream.
+pub trait DecodableMessage {
+    /// The error returned when a message fails to decode
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// The validator used to decode a validated message
+    type Validator;
+
+    /// Decode the given message, using the given validator, into its structured type
+    fn decode(msg: ValidatedMessage, validator: &Self::Validator) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+}
+
+/// A received message which can be acknowledged to prevent re-delivery by the backing message
+/// service.
+///
+/// See the documentation for acknowledging messages on [`Consumer`]
+pub struct AcknowledgeableMessage<A, M> {
+    /// The acknowledgement token which executes the ack/nack/modify operations
+    pub ack_token: A,
+
+    /// The underlying message
+    pub message: M,
+}
+
+impl<A, M> AcknowledgeableMessage<A, M>
+where
+    A: AcknowledgeToken,
+{
+    /// Acknowledge this message, declaring that processing was successful and the message should
+    /// not be re-delivered to consumers.
+    pub async fn ack(self) -> Result<M, A::AckError> {
+        self.ack_token.ack().await?;
+        Ok(self.message)
+    }
+
+    /// Negatively acknowledge this message, declaring that processing was unsuccessful and the
+    /// message should be re-delivered to consumers.
+    pub async fn nack(self) -> Result<M, A::NackError> {
+        self.ack_token.nack().await?;
+        Ok(self.message)
+    }
+
+    /// Modify the acknowledgement deadline for this message to the given number of seconds.
+    ///
+    /// The new deadline will typically be this number of seconds after the service receives this
+    /// modification requesst, though users should check their implementation's documented
+    /// behavior.
+    pub async fn modify_deadline(&mut self, seconds: u32) -> Result<(), A::ModifyError> {
+        self.ack_token.modify_deadline(seconds).await
+    }
+}
+
+impl<A, M> std::ops::Deref for AcknowledgeableMessage<A, M> {
+    type Target = M;
+
+    fn deref(&self) -> &M {
+        &self.message
+    }
+}
+
+impl<A, M> std::ops::DerefMut for AcknowledgeableMessage<A, M> {
+    fn deref_mut(&mut self) -> &mut M {
+        &mut self.message
+    }
+}
+
+/// A token associated with some message received from a message service, used to issue an
+/// ack/nack/modify request
+///
+/// See the documentation for acknowledging messages on [`Consumer`]
+#[async_trait]
+pub trait AcknowledgeToken {
+    /// Errors returned by [`ack`](AcknowledgeToken::ack)
+    type AckError: std::error::Error + Send + Sync + 'static;
+    /// Errors returned by [`nack`](AcknowledgeToken::nack)
+    type NackError: std::error::Error + Send + Sync + 'static;
+    /// Errors returned by [`modify_deadline`](AcknowledgeToken::modify_deadline)
+    type ModifyError: std::error::Error + Send + Sync + 'static;
+
+    /// Acknowledge the associated message
+    async fn ack(self) -> Result<(), Self::AckError>;
+
+    /// Negatively acknowledge the associated message
+    async fn nack(self) -> Result<(), Self::NackError>;
+
+    /// Change the associated message's acknowledge deadline to the given number of seconds
+    // uses u32 seconds instead of e.g. Duration because SQS and PubSub both have second
+    // granularity; Duration::from_millis(999) would truncate to 0, which might be surprising
+    async fn modify_deadline(&mut self, seconds: u32) -> Result<(), Self::ModifyError>;
+}
+
+/// The stream returned by the [`consume`] function
+#[pin_project]
+pub struct MessageStream<S, V, M> {
+    #[pin]
+    stream: S,
+    validator: V,
+    _message_type: std::marker::PhantomData<M>,
+}
+
+impl<S, V, M, AckToken, StreamError> stream::Stream for MessageStream<S, V, M>
+where
+    S: stream::Stream<
+        Item = Result<AcknowledgeableMessage<AckToken, ValidatedMessage>, StreamError>,
+    >,
+    M: DecodableMessage<Validator = V>,
+{
+    #[allow(clippy::type_complexity)] // it is what it is, aliases would all be generic anyway
+    type Item = Result<AcknowledgeableMessage<AckToken, M>, Either<StreamError, M::Error>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        let validator = this.validator;
+        this.stream.poll_next(cx).map(|opt| {
+            opt.map(|res| {
+                res.map_err(Either::Left).and_then(
+                    |AcknowledgeableMessage { ack_token, message }| {
+                        Ok(AcknowledgeableMessage {
+                            ack_token,
+                            message: M::decode(message, validator).map_err(Either::Right)?,
+                        })
+                    },
+                )
+            })
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,13 +105,20 @@
 #![cfg_attr(not(test), deny(unused))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use std::{collections::BTreeMap, time::SystemTime};
+use std::{borrow::Cow, collections::BTreeMap, time::SystemTime};
 pub use topic::Topic;
+
+use bytes::Bytes;
 use uuid::Uuid;
 
 #[cfg(feature = "publish")]
 #[cfg_attr(docsrs, doc(cfg(feature = "publish")))]
 pub mod publish;
+
+#[cfg(feature = "consume")]
+#[cfg_attr(docsrs, doc(cfg(feature = "consume")))]
+pub mod consume;
+
 #[cfg(test)]
 mod tests;
 mod topic;
@@ -131,7 +138,8 @@ pub type Headers = BTreeMap<String, String>;
 
 /// A validated message.
 ///
-/// The only way to construct this is via a validator.
+/// These are created by validators after encoding a user message, or when pulling messages from
+/// the message service.
 #[derive(Debug, Clone)]
 // derive Eq only in tests so that users can't foot-shoot an expensive == over data
 #[cfg_attr(test, derive(PartialEq, Eq))]
@@ -143,16 +151,31 @@ pub struct ValidatedMessage {
     /// URI of the schema validating this message.
     ///
     /// E.g. `https://hedwig.domain.xyz/schemas#/schemas/user.created/1.0`
-    schema: &'static str,
+    schema: Cow<'static, str>,
     /// Custom message headers.
     ///
     /// This may be used to track request_id, for example.
     headers: Headers,
     /// The encoded message data.
-    data: Vec<u8>,
+    data: Bytes,
 }
 
 impl ValidatedMessage {
+    /// Create a new validated message
+    pub fn new<S, D>(id: Uuid, timestamp: SystemTime, schema: S, headers: Headers, data: D) -> Self
+    where
+        S: Into<Cow<'static, str>>,
+        D: Into<Bytes>,
+    {
+        Self {
+            id,
+            timestamp,
+            schema: schema.into(),
+            headers,
+            data: data.into(),
+        }
+    }
+
     /// Unique message identifier.
     pub fn uuid(&self) -> &Uuid {
         &self.id

--- a/src/publish/mod.rs
+++ b/src/publish/mod.rs
@@ -107,12 +107,10 @@ impl PublishBatch {
     /// message ordering either.
     ///
     /// Some kinds of errors that occur during publishing may not be transient. An example of such
-    /// an error is attempting to publish a too large message with the [`GooglePubSubPublisher`].
+    /// an error is attempting to publish a too large message with the `GooglePubSubPublisher`.
     /// For
     /// errors like these retrying is most likely incorrect as they would just fail again.
     /// Publisher-specific error types may have methods to make a decision easier.
-    ///
-    /// [`GooglePubSubPublisher`]: publishers::GooglePubSubPublisher
     pub fn publish<P>(self, publisher: &P) -> PublishBatchStream<P::PublishStream>
     where
         P: Publisher,

--- a/src/publish/publishers/googlepubsub.rs
+++ b/src/publish/publishers/googlepubsub.rs
@@ -471,7 +471,7 @@ impl<'a, I> GoogleMessageSegmenter<'a, I> {
                 hedwig_publisher: &*self.identifier,
                 hedwig_message_timestamp: &timestamp,
                 hedwig_format_version: "1.0",
-                hedwig_schema: message.schema,
+                hedwig_schema: &message.schema,
                 headers: &message.headers,
             },
         })

--- a/src/publish/sink.rs
+++ b/src/publish/sink.rs
@@ -256,9 +256,9 @@ mod test {
         ValidatedMessage {
             id: uuid::Uuid::nil(),
             timestamp: std::time::SystemTime::UNIX_EPOCH,
-            schema: "test_schema",
+            schema: "test_schema".into(),
             headers: crate::Headers::default(),
-            data: data.into(),
+            data: data.into().into(),
         }
     }
 

--- a/src/validators/json_schema.rs
+++ b/src/validators/json_schema.rs
@@ -97,13 +97,13 @@ impl JsonSchemaValidator {
                 validation_state
             )));
         }
-        Ok(ValidatedMessage {
+        Ok(ValidatedMessage::new(
             id,
+            timestamp,
             schema,
             headers,
-            timestamp,
-            data: serde_json::to_vec(&value).unwrap(),
-        })
+            serde_json::to_vec(&value).map_err(JsonSchemaValidatorError::SerializeData)?,
+        ))
     }
 }
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -12,8 +12,9 @@ mod json_schema;
 pub use self::json_schema::*;
 
 #[cfg(feature = "prost")]
-mod prost;
+pub mod prost;
 #[cfg(feature = "prost")]
-pub use self::prost::*;
+pub use self::prost::{ProstDecodeError, ProstDecoder, ProstValidator, ProstValidatorError};
+
 // #[cfg_attr(docsrs, doc(cfg(feature = "prost")))]
 // pub use self::prost::ProstValidator;

--- a/src/validators/prost.rs
+++ b/src/validators/prost.rs
@@ -11,6 +11,19 @@ use crate::{Headers, ValidatedMessage};
 #[cfg_attr(docsrs, doc(cfg(feature = "prost")))]
 pub struct ProstValidatorError(#[source] prost::EncodeError);
 
+/// Errors that may occur when decoding ProtoBuf messages.
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "prost")))]
+pub enum ProstDecodeError<E: std::error::Error + 'static> {
+    /// The message's schema did not match the decoded message type
+    #[error("invalid schema for decoded message type")]
+    InvalidSchema(#[source] E),
+
+    /// The message failed to decode from protobuf
+    #[error(transparent)]
+    Decode(#[from] prost::DecodeError),
+}
+
 #[derive(Default)]
 struct UseNewToConstruct;
 
@@ -26,22 +39,131 @@ impl ProstValidator {
     }
 
     /// Validate and construct a [`ValidatedMessage`] with a protobuf payload.
-    pub fn validate<M: prost::Message>(
+    pub fn validate<M, S>(
         &self,
         id: Uuid,
         timestamp: SystemTime,
-        schema: &'static str,
+        schema: S,
         headers: Headers,
         data: &M,
-    ) -> Result<ValidatedMessage, ProstValidatorError> {
-        let mut bytes = Vec::new();
+    ) -> Result<ValidatedMessage, ProstValidatorError>
+    where
+        M: prost::Message,
+        S: Into<std::borrow::Cow<'static, str>>,
+    {
+        let mut bytes = bytes::BytesMut::new();
         data.encode(&mut bytes).map_err(ProstValidatorError)?;
-        Ok(ValidatedMessage {
-            id,
-            schema,
-            headers,
-            timestamp,
-            data: bytes,
-        })
+        Ok(ValidatedMessage::new(id, timestamp, schema, headers, bytes))
+    }
+}
+
+/// Validator that decodes data from protobuf payloads using [`prost`].
+pub struct ProstDecoder<S> {
+    schema_matcher: S,
+}
+
+impl<S> ProstDecoder<S> {
+    /// Create a new decoder with the given [`SchemaMatcher`]
+    pub fn new(schema_matcher: S) -> Self {
+        Self { schema_matcher }
+    }
+
+    /// Decode the given protobuf-encoded message into its structured data
+    pub fn decode<M>(
+        &self,
+        msg: ValidatedMessage,
+    ) -> Result<M, ProstDecodeError<S::InvalidSchemaError>>
+    where
+        S: SchemaMatcher<M>,
+        M: prost::Message + Default,
+    {
+        self.schema_matcher
+            .try_match_schema(msg.schema())
+            .map_err(ProstDecodeError::InvalidSchema)?;
+
+        Ok(M::decode(msg.data)?)
+    }
+}
+
+/// A means of asserting that an incoming message's [`schema`](ValidatedMessage::schema) matches
+/// a given message type's deserialized format.
+///
+/// For example, an implementation could check that `struct MyMessage { ... }` is a valid
+/// deserialization for an incoming message with schemas like `"my_message_v1.proto"` or
+/// `"my_message_v2.proto"`
+pub trait SchemaMatcher<MessageType> {
+    /// The error returned when a given schema does not match the message type
+    type InvalidSchemaError: std::error::Error + Send + Sync + 'static;
+
+    /// Check whether messages with the given schema are valid for deserializing into the trait's
+    /// generic message type.
+    ///
+    /// Returns an error if the schema does not match
+    fn try_match_schema(&self, schema: &str) -> Result<(), Self::InvalidSchemaError>;
+}
+
+// blanket impl SchemaMatcher over closures for convenience
+impl<T, F, E> SchemaMatcher<T> for F
+where
+    F: Fn(&str) -> Result<(), E>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    type InvalidSchemaError = E;
+
+    fn try_match_schema(&self, schema: &str) -> Result<(), Self::InvalidSchemaError> {
+        (self)(schema)
+    }
+}
+
+/// An error indicating that a received message had a schema which did not match the deserialized
+/// message type
+#[derive(Debug, Clone, Eq, PartialEq, thiserror::Error)]
+#[error("deserialized schema {encountered} does not match expected schema {expected} for type {message_type}")]
+pub struct SchemaMismatchError {
+    expected: &'static str,
+    encountered: String,
+    message_type: &'static str,
+}
+
+impl SchemaMismatchError {
+    /// Create a new error for the given message type
+    pub fn new<MessageType>(expected: &'static str, encountered: String) -> Self {
+        SchemaMismatchError {
+            expected,
+            encountered,
+            message_type: std::any::type_name::<MessageType>(),
+        }
+    }
+}
+
+/// A [`SchemaMatcher`] which expects all incoming schemas to match exactly one string for the
+/// given message type
+pub struct ExactSchemaMatcher<T> {
+    expected_schema: &'static str,
+    _message_type: std::marker::PhantomData<fn(T)>, // <fn(T)> instead of <T> to make Send + Sync unconditional
+}
+
+impl<T> ExactSchemaMatcher<T> {
+    /// Create a new schema matcher with the given expected schema
+    pub fn new(expected_schema: &'static str) -> Self {
+        Self {
+            expected_schema,
+            _message_type: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T> SchemaMatcher<T> for ExactSchemaMatcher<T> {
+    type InvalidSchemaError = SchemaMismatchError;
+
+    fn try_match_schema(&self, schema: &str) -> Result<(), Self::InvalidSchemaError> {
+        if self.expected_schema == schema {
+            Ok(())
+        } else {
+            Err(SchemaMismatchError::new::<T>(
+                self.expected_schema,
+                schema.to_owned(),
+            ))
+        }
     }
 }


### PR DESCRIPTION
This adds support for hedwig consumers -- or at least support for
implementations to be made. This includes traits for consumer streams,
message decoding, message acknowledgement, etc.

The concrete PubSub implementation currently depends on some private
crates, so it won't be included in this public repo until those
dependencies are open-sourced themselves, hopefully in the near future.

This also includes minor changes to the PubSub publisher to allow
running against a local emulator.

Fixes #5

This is a Draft PR to get an initial review of the API direction. Work still left to do:
- [x] Document everything
- [x] Re-enable the lint requiring docs on everything
- [x] unit tests
- [ ] ~A mock consumer (with acks and redelivery?)~
- [ ] ~round-trip integration tests using the mock consumer~
I've deferred the mock consumer (in progress [here](https://github.com/rnarubin/hedwig-rust/tree/mock-consumer)) because it overlaps with the external pubsub testing, so it's lower priority