### PR TITLE
Remove Arc for the Authenticator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ valico = { version = "^3.2", optional = true, default-features = false }
 base64 = { version = "^0.13", optional = true, default-features = false }
 http = { version = "^0.2", optional = true, default-features = false }
 hyper = { version = "^0.14.4", optional = true, features = ["client", "stream"], default-features = false }
-yup-oauth2 = { version = "5", optional = true, features = ["hyper-rustls"], default-features = false }
+yup-oauth2 = { version = "5.1", optional = true, features = ["hyper-rustls"], default-features = false }
 prost = { version = "0.7", optional = true, features = ["std"], default-features = false }
 
 [dev-dependencies]

--- a/examples/publish.rs
+++ b/examples/publish.rs
@@ -3,7 +3,7 @@ use hedwig::{
     publish::{EncodableMessage, GooglePubSubPublisher, Publisher},
     Headers,
 };
-use std::{env, sync::Arc, time::SystemTime};
+use std::{env, time::SystemTime};
 
 #[derive(serde::Serialize)]
 struct UserCreatedMessage {
@@ -75,13 +75,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error + 'static>> {
         .expect("$GOOGLE_APPLICATION_CREDENTIALS is not a valid service account key");
 
     let client = hyper::Client::builder().build(hyper_tls::HttpsConnector::new());
-    let authenticator = Arc::new(
-        yup_oauth2::ServiceAccountAuthenticator::builder(secret)
-            .hyper_client(client.clone())
-            .build()
-            .await
-            .expect("could not create an authenticator"),
-    );
+    let authenticator = yup_oauth2::ServiceAccountAuthenticator::builder(secret)
+        .hyper_client(client.clone())
+        .build()
+        .await
+        .expect("could not create an authenticator");
 
     let publisher = GooglePubSubPublisher::new(
         PUBLISHER.into(),

--- a/src/publish/publishers/googlepubsub.rs
+++ b/src/publish/publishers/googlepubsub.rs
@@ -174,13 +174,11 @@ impl GooglePubSubError {
 ///         .await
 ///         .expect("$GOOGLE_APPLICATION_CREDENTIALS is not a valid service account key");
 ///     let client = hyper::Client::builder().build(hyper_tls::HttpsConnector::new());
-///     let authenticator = std::sync::Arc::new(
-///         yup_oauth2::ServiceAccountAuthenticator::builder(secret)
-///              .hyper_client(client.clone())
-///              .build()
-///              .await
-///              .expect("could not create an authenticator")
-///     );
+///     let authenticator = yup_oauth2::ServiceAccountAuthenticator::builder(secret)
+///         .hyper_client(client.clone())
+///         .build()
+///         .await
+///         .expect("could not create an authenticator");
 ///     let publisher = hedwig::publish::GooglePubSubPublisher::new(
 ///         "rust_publisher".into(),
 ///         google_project.into(),
@@ -196,7 +194,7 @@ pub struct GooglePubSubPublisher<C> {
     identifier: Cow<'static, str>,
     google_cloud_project: Cow<'static, str>,
     client: hyper::Client<C>,
-    authenticator: Arc<Authenticator<C>>,
+    authenticator: Authenticator<C>,
 }
 
 impl<C> GooglePubSubPublisher<C> {
@@ -205,7 +203,7 @@ impl<C> GooglePubSubPublisher<C> {
         identifier: Cow<'static, str>,
         google_cloud_project: Cow<'static, str>,
         client: hyper::Client<C>,
-        authenticator: Arc<Authenticator<C>>,
+        authenticator: Authenticator<C>,
     ) -> GooglePubSubPublisher<C> {
         GooglePubSubPublisher {
             identifier,
@@ -219,7 +217,7 @@ impl<C> GooglePubSubPublisher<C> {
 async fn publish_single_body<C>(
     batch: Result<SegmentationResult, GooglePubSubError>,
     uri: http::uri::Uri,
-    authenticator: Arc<Authenticator<C>>,
+    authenticator: Authenticator<C>,
     client: hyper::Client<C>,
 ) -> Vec<Result<String, GooglePubSubError>>
 where


### PR DESCRIPTION
The upstream made this type cheaply cloneable, so the callers are no
longer require to wrap their `Authenticator`s into `Arc`s in order to
enable cheap cloning for the few users who may want to share the
`Authenticator`s between multiple areas in code.