### PR TITLE
Fix appending the API_BODY_SUFFIX twice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,11 +56,11 @@ base64 = { version = "^0.13", optional = true, default-features = false }
 http = { version = "^0.2", optional = true, default-features = false }
 hyper = { version = "^0.14.4", optional = true, features = ["client", "stream"], default-features = false }
 yup-oauth2 = { version = "5.1", optional = true, features = ["hyper-rustls"], default-features = false }
-prost = { version = "0.7", optional = true, features = ["std"], default-features = false }
+prost = { version = "0.8", optional = true, features = ["std"], default-features = false }
 
 [dev-dependencies]
 hyper-tls = "0.5.0"
-prost = { version = "0.7", features = ["std", "prost-derive"] }
+prost = { version = "0.8", features = ["std", "prost-derive"] }
 tokio = { version = "1", features = ["macros", "rt"] }
 serde = { version = "1", features = ["derive"] }
 


### PR DESCRIPTION
When the message batch approaches the limit we will hit the branch
within which we accidentally appended the trailing `]}` twice to the
request body.

This branch was previously covered by our tests, in particular the
`segmenter_preserves_order_when_splitting`, but due to the lack of
assertions we never actually verified that the JSON we produce is valid.

Here we remove the invalid append, and some debug assertions as well as
a regression test for this issue.

NB: this is a short term fix before #34 is ready.