### PR TITLE
Upgrade ya-gcp to 0.7.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hedwig"
-version = "5.0.0"
+version = "6.0.0"
 authors = [
     "Aniruddha Maru <aniruddhamaru@gmail.com>",
     "Simonas Kazlauskas <hedwig@kazlauskas.me>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,20 +47,20 @@ async-channel = { version = "1.6", optional = true }
 serde = { version = "^1.0", optional = true, default-features = false }
 serde_json = { version = "^1", features = ["std"], optional = true, default-features = false }
 parking_lot = { version = "0.11", optional = true }
-prost = { version = "0.8", optional = true, features = ["std"], default-features = false }
+prost = { version = "0.9", optional = true, features = ["std"], default-features = false }
 tracing = { version = "0.1.26", optional = true }
 valico = { version = "^3.2", optional = true, default-features = false }
-ya-gcp = { version = "0.6.3", features = ["pubsub"], optional = true }
+ya-gcp = { version = "0.7.2", features = ["pubsub"], optional = true }
 
 [dev-dependencies]
 async-channel = { version = "1.6" }
 futures-channel = "0.3.17"
 parking_lot = { version = "0.11" }
-prost = { version = "0.8", features = ["std", "prost-derive"] }
+prost = { version = "0.9", features = ["std", "prost-derive"] }
 tokio = { version = "1", features = ["macros", "rt"] }
-tonic = "0.5"
+tonic = "0.6"
 serde = { version = "1", features = ["derive"] }
-ya-gcp = { version = "0.6.3", features = ["pubsub", "emulators"] }
+ya-gcp = { version = "0.7", features = ["pubsub", "emulators"] }
 structopt = "0.3"
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add to Cargo.toml:
 
 ```toml
 [dependencies]
-hedwig = "5"
+hedwig = "6"
 ```
 
 You may also need to enable additional features in order to use the optional publishers or
@@ -32,7 +32,7 @@ validators, like this:
 
 ```toml
 [dependencies]
-hedwig = { version = "5", features = ["google"] }
+hedwig = { version = "6", features = ["google"] }
 ```
 
 ### Usage

--- a/src/backends/googlepubsub/consumer.rs
+++ b/src/backends/googlepubsub/consumer.rs
@@ -21,7 +21,7 @@ use ya_gcp::pubsub;
 
 use super::{
     retry_policy, AcknowledgeError, BoxError, Connect, DefaultConnector, MakeConnection,
-    ModifyAcknowledgeError, PubSubError, StatusCodeSet, StreamSubscriptionConfig, TopicName, Uri,
+    ModifyAcknowledgeError, PubSubError, StreamSubscriptionConfig, TopicName, Uri,
 };
 
 /// A PubSub subscription name.
@@ -288,9 +288,10 @@ impl crate::consumer::AcknowledgeToken for pubsub::AcknowledgeToken {
 /// Created by [`ConsumerClient::stream_subscription`]
 #[pin_project]
 #[cfg_attr(docsrs, doc(cfg(feature = "google")))]
-pub struct PubSubStream<C = DefaultConnector, R = retry_policy::ExponentialBackoff<StatusCodeSet>>(
-    #[pin] pubsub::StreamSubscription<C, R>,
-);
+pub struct PubSubStream<
+    C = DefaultConnector,
+    R = retry_policy::ExponentialBackoff<pubsub::PubSubRetryCheck>,
+>(#[pin] pubsub::StreamSubscription<C, R>);
 
 impl<C, OldR> PubSubStream<C, OldR> {
     /// Set the [`RetryPolicy`](retry_policy::RetryPolicy) to use for this streaming subscription.

--- a/src/backends/googlepubsub/mod.rs
+++ b/src/backends/googlepubsub/mod.rs
@@ -5,11 +5,12 @@
 use std::{borrow::Cow, fmt::Display};
 
 pub use ya_gcp::{
+    self as gcp,
     grpc::StatusCodeSet,
     pubsub::{
         AcknowledgeError, AcknowledgeToken, BuildError, Error as PubSubError, MakeConnection,
-        ModifyAcknowledgeError, PubSubConfig, SinkError, StreamSubscriptionConfig, Uri,
-        DEFAULT_RETRY_CODES,
+        ModifyAcknowledgeError, PubSubConfig, PubSubRetryCheck, SinkError,
+        StreamSubscriptionConfig, Uri,
     },
     retry_policy, AuthFlow, ClientBuilderConfig, Connect, CreateBuilderError, DefaultConnector,
     ServiceAccountAuth,

--- a/src/backends/googlepubsub/publisher.rs
+++ b/src/backends/googlepubsub/publisher.rs
@@ -19,8 +19,7 @@ use super::{
         exponential_backoff::Config as ExponentialBackoffConfig, ExponentialBackoff,
         RetryOperation, RetryPolicy,
     },
-    BoxError, Connect, DefaultConnector, MakeConnection, PubSubError, StatusCodeSet, TopicName,
-    Uri,
+    BoxError, Connect, DefaultConnector, MakeConnection, PubSubError, TopicName, Uri,
 };
 
 use message_translate::{TopicSink, TopicSinkError};
@@ -199,7 +198,7 @@ where
         Publisher {
             client: self.clone(),
             retry_policy: ExponentialBackoff::new(
-                pubsub::DEFAULT_RETRY_CODES,
+                pubsub::PubSubRetryCheck::default(),
                 ExponentialBackoffConfig::default(),
             ),
         }
@@ -214,7 +213,7 @@ where
 }
 
 /// A publisher for sending messages to PubSub topics
-pub struct Publisher<C, R = ExponentialBackoff<StatusCodeSet>> {
+pub struct Publisher<C, R = ExponentialBackoff<pubsub::PubSubRetryCheck>> {
     client: PublisherClient<C>,
     retry_policy: R,
 }


### PR DESCRIPTION
This upgrades the GCP client library used for the google backend from 0.6 to 0.7. This new version includes several fixes for retrying PubSub streaming connections when encountering errors.

The gRPC and protobuf libraries tonic and prost are upgraded to their latest versions as well.