### PR TITLE
Fix retry policy bounds on PubSubStream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hedwig"
-version = "6.0.0"
+version = "6.0.1"
 authors = [
     "Aniruddha Maru <aniruddhamaru@gmail.com>",
     "Simonas Kazlauskas <hedwig@kazlauskas.me>",


### PR DESCRIPTION
Previously, the google PubSub subscription backend only implemented the
Stream and Consumer traits when the default retry policy was used, via
the default generic type parameter. This change adds the trait bounds to
allow generic retry policies