### PR TITLE
Expose the underlying pubsub client

### DIFF
--- a/.github/workflows/hedwig.yml
+++ b/.github/workflows/hedwig.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         rust_toolchain: [nightly, stable, 1.53.0]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "hedwig"
-version = "6.0.1"
+version = "6.2.0"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hedwig"
-version = "6.1.0"
+version = "6.2.0"
 authors = [
     "Aniruddha Maru <aniruddhamaru@gmail.com>",
     "Simonas Kazlauskas <hedwig@kazlauskas.me>",


### PR DESCRIPTION
This change exposes the PubSub gRPC client used by the Hedwig client with the googlepubsub backend on its public interface. This allows controlling behavior that isn't explicitly covered by the Hedwig interface, for example updating a subscription's settings.