### PR TITLE
Support runtime Topic designation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
+ "smallstr",
  "structopt",
  "thiserror",
  "tokio",
@@ -1275,6 +1276,15 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "smallstr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b1aefdf380735ff8ded0b15f31aab05daf1f70216c01c02a12926badd1df9d"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hedwig"
-version = "6.3.0"
+version = "6.4.0"
 authors = [
     "Aniruddha Maru <aniruddhamaru@gmail.com>",
     "Simonas Kazlauskas <hedwig@kazlauskas.me>",
@@ -39,6 +39,7 @@ bytes = "1"
 either = { version = "1", features = ["use_std"], default-features = false }
 futures-util = { version = "0.3.17", features = ["std", "sink"], default-features = false }
 pin-project = "1"
+smallstr = { version = "0.3.0", features = ["union"] }
 thiserror = { version = "1", default-features = false }
 url = { version = "2", default-features = false }
 uuid = { version = "^0.8", features = ["v4"], default-features = false }

--- a/src/topic.rs
+++ b/src/topic.rs
@@ -1,21 +1,36 @@
-/// A message queue topic name to which messages can be published
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct Topic(&'static str);
+use smallstr::SmallString;
 
-impl std::fmt::Display for Topic {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.0, f)
+/// A message queue topic name to which messages can be published
+// A survey of common topics found lengths between 16 and 35 bytes
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Topic(SmallString<[u8; 36]>);
+
+impl Default for Topic {
+    fn default() -> Self {
+        Topic(SmallString::new())
     }
 }
 
-impl From<&'static str> for Topic {
-    fn from(s: &'static str) -> Topic {
-        Topic(s)
+impl std::fmt::Display for Topic {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.0.as_str(), f)
+    }
+}
+
+impl<'a> From<&'a str> for Topic {
+    fn from(s: &'a str) -> Topic {
+        Topic(s.into())
+    }
+}
+
+impl From<String> for Topic {
+    fn from(s: String) -> Topic {
+        Topic(s.into())
     }
 }
 
 impl AsRef<str> for Topic {
     fn as_ref(&self) -> &str {
-        self.0
+        self.0.as_ref()
     }
 }


### PR DESCRIPTION
Previously the Topic type was only constructible from static strings. This works for code-gen messages, but doesn't work if the topic needs to be determined at runtime. This change permits constructing Topics from arbitrary strings