### PR TITLE
Don't doc deps in CI

### DIFF
--- a/.github/workflows/hedwig.yml
+++ b/.github/workflows/hedwig.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --all-features --manifest-path=Cargo.toml
+          args: --all-features --manifest-path=Cargo.toml --no-deps
         env:
           RUSTDOCFLAGS: --cfg docsrs -Dmissing_docs -Drustdoc::broken_intra_doc_links
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,3 +1,5 @@
+//! Message related types
+
 use bytes::Bytes;
 use std::{borrow::Cow, time::SystemTime};
 use uuid::Uuid;

--- a/src/validators/prost.rs
+++ b/src/validators/prost.rs
@@ -1,4 +1,4 @@
-//! Validation and decoding for messages encoded with protobuf using [`prost`](::prost)
+//! Validation and decoding for messages encoded with protobuf using [`prost`]
 //!
 //! ```
 //! use hedwig::validators::prost::{ProstValidator, ProstDecoder, ExactSchemaMatcher};


### PR DESCRIPTION
Previously the CI documentation build would include dependency documentation. We're only actually interested in doc validity in our own code, so no sense generating docs for deps.

This should fix the doc failures in CI